### PR TITLE
php7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/php:7.1.13-cli-jessie
+            - image: cimg/php:7.4
         steps:
             - checkout
             - restore_cache:

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
-        "symfony/var-dumper": "^4.2"
+        "symfony/var-dumper": "^5.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.2.5"
+            "php": "7.4.30"
         }
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.4.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.5.7|^7.4.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.26",
+        "phpunit/phpunit": "^9.5.20",
         "symfony/var-dumper": "^4.2"
     }
 }


### PR DESCRIPTION
- Bumps minimum PHP version to 7.4 (receives security fixes).
- Update CircleCI PHP image.