### PR TITLE
Added getParcelDocument for the /parcels/{id}/documents/{type} endpoint

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace JouwWeb\Sendcloud;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Utils;
 use JouwWeb\Sendcloud\Exception\SendcloudClientException;
 use JouwWeb\Sendcloud\Exception\SendcloudRequestException;
@@ -452,6 +453,46 @@ class Client
             return (string)$this->guzzleClient->get($labelUrl)->getBody();
         } catch (TransferException $exception) {
             throw $this->parseGuzzleException($exception, 'Could not retrieve label PDF data.');
+        }
+    }
+
+
+    /**
+     * Fetches a single parcel document based on requested document type, content type, and dpi.
+     *
+     * If the parcel hasn't had its labels created through {@see self::createLabel()} it will result in an exception.
+     *
+     * @param string $documentType One of `Parcel::DOCUMENT_TYPES`
+     * @param string $contentType One of `Parcel::CONTENT_TYPES`
+     * @param int $dpi One of `Parcel::DPI_VALUES` limited by the selected `$contentType`
+     * @return string The contents of the requested document
+     * @throws SendcloudClientException
+     */
+    public function getParcelDocument(Parcel|int $parcelId, string $documentType, string $contentType = Parcel::CONTENT_TYPE_PDF, int $dpi = Parcel::DPI_72): string
+    {
+        if (!in_array($documentType, Parcel::DOCUMENT_TYPES, true)) {
+            throw new \InvalidArgumentException(sprintf('Document type "%s" is not accepted. Valid types: %s.', $documentType, implode(', ', Parcel::DOCUMENT_TYPES)));
+        }
+
+        if (!in_array($contentType, Parcel::CONTENT_TYPES, true)) {
+            throw new \InvalidArgumentException(sprintf('Content type "%s" is not accepted. Valid types: %s.', $contentType, implode(', ', Parcel::CONTENT_TYPES)));
+        }
+
+        if (!in_array($dpi, Parcel::DPI_VALUES[$contentType] ?? [], true)) {
+            throw new \InvalidArgumentException(sprintf('DPI "%d" is not accepted for "%s". Valid values: %s.', $dpi, $contentType, implode(', ', Parcel::DPI_VALUES[$contentType])));
+        }
+
+        if ($parcelId instanceof Parcel) {
+            $parcelId = $parcelId->getId();
+        }
+
+        try {
+            return (string)$this->guzzleClient->get(sprintf('parcels/%s/documents/%s', $parcelId, $documentType), [
+                RequestOptions::QUERY => ['dpi' => $dpi],
+                RequestOptions::HEADERS => ['Accept' => $contentType],
+            ])->getBody();
+        } catch (TransferException $exception) {
+            throw $this->parseGuzzleException($exception, sprintf('Could not retrieve parcel document "%s" for parcel id "%d".', $documentType, $parcelId));
         }
     }
 

--- a/src/Model/Parcel.php
+++ b/src/Model/Parcel.php
@@ -86,6 +86,43 @@ class Parcel
         self::CUSTOMS_SHIPMENT_TYPE_RETURNED_GOODS,
     ];
 
+    public const DOCUMENT_TYPE_AIR_WAYBILL = 'air-waybill';
+    public const DOCUMENT_TYPE_CN23 = 'cn23';
+    public const DOCUMENT_TYPE_CN23_DEFAULT = 'cn23-default';
+    public const DOCUMENT_TYPE_COMMERCIAL_INVOICE = 'commercial-invoice';
+    public const DOCUMENT_TYPE_CP71 = 'cp71';
+    public const DOCUMENT_TYPE_LABEL = 'label';
+    public const DOCUMENT_TYPE_QR = 'qr';
+    public const DOCUMENT_TYPES = [
+        self::DOCUMENT_TYPE_AIR_WAYBILL,
+        self::DOCUMENT_TYPE_CN23,
+        self::DOCUMENT_TYPE_CN23_DEFAULT,
+        self::DOCUMENT_TYPE_COMMERCIAL_INVOICE,
+        self::DOCUMENT_TYPE_CP71,
+        self::DOCUMENT_TYPE_LABEL,
+        self::DOCUMENT_TYPE_QR,
+    ];
+
+    public const CONTENT_TYPE_PDF = 'application/pdf';
+    public const CONTENT_TYPE_ZPL = 'application/zpl';
+    public const CONTENT_TYPE_PNG = 'image/png';
+    public const CONTENT_TYPES = [
+        self::CONTENT_TYPE_PDF,
+        self::CONTENT_TYPE_ZPL,
+        self::CONTENT_TYPE_PNG,
+    ];
+
+    public const DPI_72 = 72;
+    public const DPI_150 = 150;
+    public const DPI_203 = 203;
+    public const DPI_300 = 300;
+    public const DPI_600 = 600;
+    public const DPI_VALUES = [
+        self::CONTENT_TYPE_PDF => [self::DPI_72],
+        self::CONTENT_TYPE_ZPL => [self::DPI_203, self::DPI_300, self::DPI_600],
+        self::CONTENT_TYPE_PNG => [self::DPI_150, self::DPI_300],
+    ];
+
     /**
      * Constants for the 'errors' query parameter for parcel creation
      * @see https://api.sendcloud.dev/docs/sendcloud-public-api/parcels-and-error-handling#errorsverbose

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -4,6 +4,7 @@ namespace Test\JouwWeb\Sendcloud;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use JouwWeb\Sendcloud\Client;
@@ -559,5 +560,50 @@ class ClientTest extends TestCase
         $this->assertTrue($servicePoint->isOpenTomorrow());
         $this->assertTrue($servicePoint->isOpenUpcomingWeek());
         $this->assertEquals(361, $servicePoint->getDistance());
+    }
+
+    public function testGetParcelDocumentErrorsWithAnInvalidDocumentType(): void
+    {
+        $this->expectExceptionMessage(sprintf('Document type "invalid document type" is not accepted. Valid types: %s.', implode(', ', Parcel::DOCUMENT_TYPES)));
+        $this->client->getParcelDocument(1, 'invalid document type', 'invalid content type', 0);
+    }
+
+    public function testGetParcelDocumentErrorsWithAnInvalidContentType(): void
+    {
+        $this->expectExceptionMessage(sprintf('Content type "invalid content type" is not accepted. Valid types: %s.', implode(', ', Parcel::CONTENT_TYPES)));
+        $this->client->getParcelDocument(1, Parcel::DOCUMENT_TYPE_LABEL, 'invalid content type', 0);
+    }
+
+    public function contentTypesProvider(): array
+    {
+        return array_map(static fn (string $value) => [$value], Parcel::CONTENT_TYPES);
+    }
+
+    /** @dataProvider contentTypesProvider */
+    public function testGetParcelDocumentErrorsWithAnDpiPerContentType(string $contentType): void
+    {
+        $this->expectExceptionMessage(sprintf('DPI "0" is not accepted for "%s". Valid values: %s.', $contentType, implode(', ', Parcel::DPI_VALUES[$contentType])));
+        $this->client->getParcelDocument(1, Parcel::DOCUMENT_TYPE_LABEL, $contentType, 0);
+    }
+
+    public function testGetParcelDocumentRethrowsTheCorrectException(): void
+    {
+        $this->guzzleClientMock->method('request')->willThrowException(new TransferException('Whoops'));
+
+        $this->expectException(SendcloudRequestException::class);
+        $this->expectExceptionMessage(sprintf('Could not retrieve parcel document "%s" for parcel id "1".', Parcel::DOCUMENT_TYPE_LABEL));
+
+        $this->client->getParcelDocument(1, Parcel::DOCUMENT_TYPE_LABEL, Parcel::CONTENT_TYPE_ZPL, Parcel::DPI_203);
+    }
+
+    public function testGetParcelDocumentReturnsTheRequestedContent(): void
+    {
+        $this->guzzleClientMock->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            [],
+            'The ZPL content'
+        ));
+
+        $this->assertEquals('The ZPL content', $this->client->getParcelDocument(1, Parcel::DOCUMENT_TYPE_LABEL, Parcel::CONTENT_TYPE_ZPL, Parcel::DPI_203));
     }
 }


### PR DESCRIPTION
I've added some basic validation of the request parameters based on the [Sendcloud API documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcel-documents%2Foperations%2Fget-a-parcel-document) and added a few tests to verify these scenarios. I wasn't sure about codestyle and function imports so based my changes off existing code. 

Closes #31