### PR TITLE
Added apply_shipping_rules support to the createLabel call

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -178,7 +178,8 @@ class Client
             $customsInvoiceNumber,
             $customsShipmentType,
             $items,
-            $postNumber
+            $postNumber,
+            false
         );
 
         try {
@@ -240,7 +241,8 @@ class Client
             $customsInvoiceNumber,
             $customsShipmentType,
             $items,
-            $postNumber
+            $postNumber,
+            false
         );
         $parcelData['quantity'] = $quantity;
 
@@ -299,7 +301,8 @@ class Client
             null,
             null,
             null,
-            null
+            null,
+            false
         );
 
         try {
@@ -317,11 +320,13 @@ class Client
 
     /**
      * Request a label for an existing parcel.
- * @param SenderAddress|Address|int|null $senderAddress Passing null will pick Sendcloud's default. An Address will
+     * @param SenderAddress|Address|int|null $senderAddress Passing null will pick Sendcloud's default. An Address will
      * use undocumented behavior that will disable branding personalizations.
+     * @param bool $applyShippingRules shipping rules can override the given shippingMethod and can be configured in the
+     * sendcloud control panel
      * @throws SendcloudRequestException
      */
-    public function createLabel(Parcel|int $parcel, ShippingMethod|int $shippingMethod, SenderAddress|Address|int|null $senderAddress): Parcel
+    public function createLabel(Parcel|int $parcel, ShippingMethod|int $shippingMethod, SenderAddress|Address|int|null $senderAddress, bool $applyShippingRules = false): Parcel
     {
         $parcelData = $this->getParcelData(
             $this->parseParcelArgument($parcel),
@@ -335,7 +340,8 @@ class Client
             null,
             null,
             null,
-            null
+            null,
+            $applyShippingRules
         );
 
         try {
@@ -671,7 +677,8 @@ class Client
         ?string $customsInvoiceNumber,
         ?int $customsShipmentType,
         ?array $items,
-        ?string $postNumber
+        ?string $postNumber,
+        bool $applyShippingRules = false
     ): array {
         $parcelData = [];
 
@@ -759,6 +766,10 @@ class Client
             }
 
             $parcelData['parcel_items'] = $itemsData;
+        }
+
+        if ($applyShippingRules) {
+            $parcelData['apply_shipping_rules'] = true;
         }
 
         // Additional fields are only added when requesting a label


### PR DESCRIPTION
When requesting labels it can also apply [shipping rules](https://support.sendcloud.com/hc/en-us/articles/10274644599316-Shipping-rules-overview-and-application) when this feature is available. This will effectively override the shipping method given.

I've given it a default value in `getParcelData` to ensure backwards compatibility due to this method being protected. I've added `false` as default value to the callers as all parameter values are explicitly passed along, but can change this if desired.