### PR TITLE
http-client-interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "php": ">=8.1.0",
         "ext-json": "*",
         "psr/http-message": "^2.0",
-        "symfony/http-client": "^6.0||^7.0"
+        "symfony/http-client": "^6.0||^7.0",
+        "symfony/http-client-contracts": "^3.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "require": {
         "php": ">=8.1.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.4.5"
+        "guzzlehttp/guzzle": "^7.4.5",
+        "symfony/http-client": "^6.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0.0",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/http-client": "^6.0||^7.0"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^2.7",
         "phpunit/phpunit": "^10.0.0",
         "symfony/var-dumper": "^6.0.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
     "require": {
         "php": ">=8.1.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.4.5",
-        "symfony/http-client": "^6.4"
+        "psr/http-message": "^2.0",
+        "symfony/http-client": "^6.0||^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0.0",

--- a/src/Exception/SendcloudRequestException.php
+++ b/src/Exception/SendcloudRequestException.php
@@ -10,12 +10,14 @@ class SendcloudRequestException extends SendcloudClientException
     public const CODE_NOT_ALLOWED_TO_ANNOUNCE = 2;
     public const CODE_UNAUTHORIZED = 3;
     public const CODE_CONNECTION_FAILED = 4;
+    public const CODE_UNEXPECTED_RESPONSE = 5;
     public const CODES = [
         self::CODE_UNKNOWN,
         self::CODE_NO_ADDRESS_DATA,
         self::CODE_NOT_ALLOWED_TO_ANNOUNCE,
         self::CODE_UNAUTHORIZED,
         self::CODE_CONNECTION_FAILED,
+        self::CODE_UNEXPECTED_RESPONSE,
     ];
 
     public function __construct(

--- a/src/HttpClientTrait.php
+++ b/src/HttpClientTrait.php
@@ -29,7 +29,6 @@ trait HttpClientTrait
         }
         $requestOptions->setHeaders($headers);
 
-        // TODO: Only require contracts and fall back to HttpClient when package is installed (exception otherwise)?
         return $httpClient?->withOptions($requestOptions->toArray()) ?? HttpClient::create($requestOptions->toArray());
     }
 }

--- a/src/HttpClientTrait.php
+++ b/src/HttpClientTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace JouwWeb\Sendcloud;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\HttpOptions;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+trait HttpClientTrait
+{
+    private function createHttpClient(
+        ?HttpClientInterface $httpClient,
+        string $apiBaseUrl,
+        string $publicKey,
+        string $secretKey,
+        ?string $partnerId = null,
+    ): HttpClientInterface {
+        $requestOptions = new HttpOptions();
+        $requestOptions->setBaseUri($apiBaseUrl);
+        // Mainly because the shipping methods endpoint can take a very long time to respond.
+        $requestOptions->setTimeout(60);
+        $requestOptions->setAuthBasic($publicKey, $secretKey);
+
+        $headers = [
+            'User-Agent' => 'jouwweb/sendcloud',
+        ];
+        if ($partnerId) {
+            $headers['Sendcloud-Partner-Id'] = $partnerId;
+        }
+        $requestOptions->setHeaders($headers);
+
+        return $httpClient?->withOptions($requestOptions->toArray()) ?? HttpClient::create($requestOptions->toArray());
+    }
+}

--- a/src/HttpClientTrait.php
+++ b/src/HttpClientTrait.php
@@ -29,6 +29,7 @@ trait HttpClientTrait
         }
         $requestOptions->setHeaders($headers);
 
+        // TODO: Only require contracts and fall back to HttpClient when package is installed (exception otherwise)?
         return $httpClient?->withOptions($requestOptions->toArray()) ?? HttpClient::create($requestOptions->toArray());
     }
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -4,12 +4,12 @@ namespace JouwWeb\Sendcloud;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\TransferException;
 use JouwWeb\Sendcloud\Exception\SendcloudRequestException;
 use JouwWeb\Sendcloud\Exception\SendcloudWebhookException;
 use JouwWeb\Sendcloud\Model\Parcel;
 use JouwWeb\Sendcloud\Model\WebhookEvent;
 use Psr\Http\Message\RequestInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class Utility
 {
@@ -86,7 +86,7 @@ class Utility
     }
 
     public static function parseGuzzleException(
-        TransferException $exception,
+        TransportExceptionInterface $exception,
         string $defaultMessage
     ): SendcloudRequestException {
         $message = $defaultMessage;

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -79,8 +79,8 @@ class ClientTest extends TestCase
 
     public function testGetShippingProducts(): void
     {
-        $shippingProduct1 = '{"name":"Shipping product 1","carrier":"carrier_code_1","available_functionalities":{"last_mile":["home_delivery"],"returns":[false]},"methods":[{"id":2,"name":"B- Heavy weight shipment","properties":{ "min_weight":51,"max_weight":1001}},{"id":1,"name":"A- Low weight shipment","properties":{ "min_weight":1,"max_weight":51}}],"weight_range":{"min_weight":1,"max_weight":1001}}';
-        $shippingProduct2 = '{"name":"Shipping product 2","carrier":"carrier_code_2","available_functionalities":{"last_mile":["service_point"],"returns":[true]},"methods":[{"id":3,"name":"C- Heavy weight shipment","properties":{ "min_weight":1000,"max_weight":2001}}],"weight_range":{"min_weight":1000,"max_weight":2001}}';
+        $shippingProduct1 = '{"name":"Shipping product 1","carrier":"carrier_code_1","available_functionalities":{"last_mile":["home_delivery"],"returns":[false]},"methods":[{"id":2,"name":"B- Heavy weight shipment","properties":{"min_weight":51,"max_weight":1001}},{"id":1,"name":"A- Low weight shipment","properties":{"min_weight":1,"max_weight":51}}],"weight_range":{"min_weight":1,"max_weight":1001}}';
+        $shippingProduct2 = '{"name":"Shipping product 2","carrier":"carrier_code_2","available_functionalities":{"last_mile":["service_point"],"returns":[true]},"methods":[{"id":3,"name":"C- Heavy weight shipment","properties":{"min_weight":1000,"max_weight":2001}}],"weight_range":{"min_weight":1000,"max_weight":2001}}';
         $response = new MockResponse(sprintf('[%s,%s]', $shippingProduct1, $shippingProduct2));
         $this->configureApiResponse($response);
 
@@ -116,29 +116,8 @@ class ClientTest extends TestCase
 
     public function testGetShippingProductsCaseAllOptionalArguments(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturnCallback(function () {
-            $this->assertEquals([
-                'GET',
-                'shipping-products',
-                ['query' => [
-                    'from_country' => 'NL',
-                    'last_mile' => ShippingProduct::DELIVERY_MODE_SERVICE_POINT,
-                    'to_country' => 'EN',
-                    'carrier' => 'carrier_code_2',
-                    'weight' => 1500,
-                    'weight_unit' => ShippingProduct::WEIGHT_UNIT_GRAM,
-                    'returns' => true,
-                ]],
-            ], func_get_args());
-
-            $shippingProduct = '{"name": "Shipping product 2", "carrier": "carrier_code_2", "available_functionalities": {"last_mile": ["service_point"]},"methods": [{"id": 2, "name": "B- Heavy weight shipment","properties": { "min_weight": 1000, "max_weight": 2001}}],"weight_range":{"min_weight": 1000,"max_weight": 2001}}';
-
-            return new Response(
-                200,
-                [],
-                "[$shippingProduct]"
-            );
-        });
+        $response = new MockResponse('[{"name":"Shipping product 2","carrier":"carrier_code_2","available_functionalities":{"last_mile":["service_point"]},"methods":[{"id":2,"name":"B- Heavy weight shipment","properties":{"min_weight":1000,"max_weight":2001}}],"weight_range":{"min_weight":1000,"max_weight":2001}}]');
+        $this->configureApiResponse($response);
 
         $shippingMethods = $this->client->getShippingProducts(
             'NL',
@@ -150,29 +129,18 @@ class ClientTest extends TestCase
             1
         );
 
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/shipping-products?from_country=NL&last_mile=service_point&to_country=EN&carrier=carrier_code_2&weight=1500&weight_unit=gram&returns=1', $response->getRequestUrl());
         $this->assertCount(1, $shippingMethods);
     }
 
     public function testGetShippingProductsCaseEmptyResponse(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturnCallback(function () {
-            $this->assertEquals([
-                'GET',
-                'shipping-products',
-                ['query' => [
-                    'from_country' => 'NL'
-                ]],
-            ], func_get_args());
-
-            return new Response(
-                200,
-                [],
-                "[]"
-            );
-        });
+        $response = new MockResponse('[]');
+        $this->configureApiResponse($response);
 
         $shippingMethods = $this->client->getShippingProducts(fromCountry: 'NL');
 
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/shipping-products?from_country=NL', $response->getRequestUrl());
         $this->assertCount(0, $shippingMethods);
     }
 
@@ -209,14 +177,12 @@ class ClientTest extends TestCase
 
     public function testGetSenderAddresses(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"sender_addresses":[{"id":92837,"company_name":"AwesomeCo Inc.","contact_name":"Bertus Bernardus","email":"bertus@awesomeco.be","telephone":"+31683749586","street":"Wegstraat","house_number":"233","postal_box":"","postal_code":"8398","city":"Brussel","country":"BE"},{"id":28397,"company_name":"AwesomeCo Inc. NL","contact_name":"","email":"","telephone":"0645000000","street":"Torenallee","house_number":"20","postal_box":"","postal_code":"5617 BC","city":"Eindhoven","country":"NL"}]}'
-        ));
+        $response = new MockResponse('{"sender_addresses":[{"id":92837,"company_name":"AwesomeCo Inc.","contact_name":"Bertus Bernardus","email":"bertus@awesomeco.be","telephone":"+31683749586","street":"Wegstraat","house_number":"233","postal_box":"","postal_code":"8398","city":"Brussel","country":"BE"},{"id":28397,"company_name":"AwesomeCo Inc. NL","contact_name":"","email":"","telephone":"0645000000","street":"Torenallee","house_number":"20","postal_box":"","postal_code":"5617 BC","city":"Eindhoven","country":"NL"}]}');
+        $this->configureApiResponse($response);
 
         $senderAddresses = $this->client->getSenderAddresses();
 
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/user/addresses/sender', $response->getRequestUrl());
         $this->assertCount(2, $senderAddresses);
         $this->assertEquals(92837, $senderAddresses[0]->getId());
         $this->assertEquals('AwesomeCo Inc.', $senderAddresses[0]->getCompanyName());
@@ -225,11 +191,8 @@ class ClientTest extends TestCase
 
     public function testCreateParcel(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"parcel":{"id":8293794,"address":"straat 23","address_2":"Blok 3","address_divided":{"house_number":"23","street":"straat"},"city":"Gehucht","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"baron@vanderzanden.nl","name":"Baron van der Zanden","postal_code":"9283DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"2.486","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CA","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001"}}'
-        ));
+        $response = new MockResponse('{"parcel":{"id":8293794,"address":"straat 23","address_2":"Blok 3","address_divided":{"house_number":"23","street":"straat"},"city":"Gehucht","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"baron@vanderzanden.nl","name":"Baron van der Zanden","postal_code":"9283DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"2.486","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CA","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001"}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->createParcel(
             new Address('Baron van der Zanden', null, 'straat', '23', 'Gehucht', '9283DD', 'NL', 'baron@vanderzanden.nl', 'Blok 3', 'CA'),
@@ -238,6 +201,9 @@ class ClientTest extends TestCase
             2486
         );
 
+        $this->assertEquals('POST', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels', $response->getRequestUrl());
+        $this->assertEquals('{"parcel":{"name":"Baron van der Zanden","company_name":"","address":"straat","address_2":"CA","house_number":"baron@vanderzanden.nl","city":"23","postal_code":"Gehucht","country":"9283DD","email":"NL","telephone":"Blok 3","country_state":"","order_number":"201900001","weight":"2.486"}}', $response->getRequestOptions()['body']);
         $this->assertEquals(8293794, $parcel->getId());
         $this->assertEquals(Parcel::STATUS_NO_LABEL, $parcel->getStatusId());
         $this->assertEquals(new \DateTimeImmutable('2019-03-11 14:35:10'), $parcel->getCreated());
@@ -254,11 +220,8 @@ class ClientTest extends TestCase
 
     public function testCreateParcelWithVerboseError(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"parcel":{"id":8293794,"address":"straat 23","address_2":"Blok 3","address_divided":{"house_number":"23","street":"straat"},"city":"Gehucht","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"baron@vanderzanden.nl","name":"Baron van der Zanden","postal_code":"9283DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"2.486","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CA","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001", "errors" : {"name": "This field is required."}}}'
-        ));
+        $response = new MockResponse('{"parcel":{"id":8293794,"address":"straat 23","address_2":"Blok 3","address_divided":{"house_number":"23","street":"straat"},"city":"Gehucht","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"baron@vanderzanden.nl","name":"Baron van der Zanden","postal_code":"9283DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"2.486","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CA","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001","errors":{"name":"This field is required."}}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->createParcel(
             new Address('', null, 'straat', '23', 'Gehucht', '9283DD', 'NL', 'baron@vanderzanden.nl', 'Blok 3', 'CA'),
@@ -273,6 +236,7 @@ class ClientTest extends TestCase
             Parcel::ERROR_VERBOSE
         );
 
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels?errors=verbose', $response->getRequestUrl());
         $this->assertEquals(8293794, $parcel->getId());
         $this->assertEquals(Parcel::STATUS_NO_LABEL, $parcel->getStatusId());
         $this->assertEquals(new \DateTimeImmutable('2019-03-11 14:35:10'), $parcel->getCreated());
@@ -332,12 +296,8 @@ class ClientTest extends TestCase
     public function testCreateMultiParcelWithVerboseError(): void
     {
         $parcelJson = '{"name":"Baron van der Zanden","company_name":"","address":"straat","address_2":"CA","house_number":"23","city":"Gehucht","postal_code":"9283DD","country":"NL","email":"baron@vanderzanden.nl","telephone":"Blok 3","country_state":"","order_number":"201900001","weight":"2.486","request_label":true,"shipment":{"id":1},"quantity":2}';
-
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"parcels": [], "failed_parcels": [{"parcel":'.$parcelJson.', "errors": { "name": ["This field is required."]}}]}'
-        ));
+        $response = new MockResponse(sprintf('{"parcels":[],"failed_parcels":[{"parcel":%s,"errors":{"name":["This field is required."]}}]}', $parcelJson));
+        $this->configureApiResponse($response);
 
         $parcels = $this->client->createMultiParcel(
             new Address('Baron van der Zanden', null, 'straat', '23', 'Gehucht', '9283DD', 'NL', 'baron@vanderzanden.nl', 'Blok 3', 'CA'),
@@ -353,21 +313,14 @@ class ClientTest extends TestCase
             2
         );
 
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels?errors=verbose', $response->getRequestUrl());
         $this->assertCount(0, $parcels);
     }
 
     public function testCreateParcelCustoms(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')
-            ->willReturnCallback(function () {
-                $this->assertEquals([
-                    'POST',
-                    'parcels',
-                    ['json' => ['parcel' => ['name' => 'Dr. Coffee', 'company_name' => '', 'address' => 'Street', 'house_number' => '123', 'address_2' => 'Unit 83', 'city' => 'Place', 'postal_code' => '7837', 'country' => 'BM', 'email' => 'drcoffee@drcoffee.dr', 'telephone' => '', 'country_state' => '', 'customs_invoice_nr' => 'customsInvoiceNumber', 'customs_shipment_type' => 2, 'parcel_items' => [0 => ['description' => 'green tea', 'quantity' => 1, 'weight' => '0.123', 'value' => 15.2, 'hs_code' => '090210', 'origin_country' => 'EC'], 1 => ['description' => 'cardboard', 'quantity' => 3, 'weight' => '0.050','value' => 0.2, 'hs_code' => '090210', 'origin_country' => 'NL', 'sku' => 'SKUSKUSKU', 'product_id' => 'Product2839', 'properties' => ['propertyKey' => 'propertyValue']]]]]],
-                ], func_get_args());
-
-                return new Response(200, [], '{"parcel":{"id":36054805,"address":"Street 123","address_2":"Unit 83","address_divided":{"house_number":"123","street":"Street"},"city":"Place","company_name":"","country":{"iso_2":"BM","iso_3":"BMU","name":"Bermuda"},"data":{},"date_created":"06-02-2020 21:33:13","email":"drcoffee@drcoffee.dr","name":"Dr. Coffee","postal_code":"7837","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"1.000","label":{},"customs_declaration":{},"order_number":"","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"customsInvoiceNumber","customs_shipment_type":2,"parcel_items":[{"description":"cardboard","quantity":3,"weight":"0.050","value":"0.20","hs_code":"090210","origin_country":"NL","product_id":"","properties":{},"sku":"","return_reason":null,"return_message":null},{"description":"green tea","quantity":1,"weight":"0.123","value":"15.20","hs_code":"090210","origin_country":"EC","product_id":"Product2839","properties":{"propertyKey":"propertyValue"},"sku":"SKUSKUSKU","return_reason":null,"return_message":null}],"documents":[],"type":null,"shipment_uuid":"f893c98c-43a6-49bb-9dda-9bf3e76a87ad","shipping_method":null,"external_order_id":"36054805","external_shipment_id":"","external_reference":null,"is_return":false,"note":""}}');
-            });
+        $response = new MockResponse('{"parcel":{"id":36054805,"address":"Street 123","address_2":"Unit 83","address_divided":{"house_number":"123","street":"Street"},"city":"Place","company_name":"","country":{"iso_2":"BM","iso_3":"BMU","name":"Bermuda"},"data":{},"date_created":"06-02-2020 21:33:13","email":"drcoffee@drcoffee.dr","name":"Dr. Coffee","postal_code":"7837","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"1.000","label":{},"customs_declaration":{},"order_number":"","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"customsInvoiceNumber","customs_shipment_type":2,"parcel_items":[{"description":"cardboard","quantity":3,"weight":"0.050","value":"0.20","hs_code":"090210","origin_country":"NL","product_id":"","properties":{},"sku":"","return_reason":null,"return_message":null},{"description":"green tea","quantity":1,"weight":"0.123","value":"15.20","hs_code":"090210","origin_country":"EC","product_id":"Product2839","properties":{"propertyKey":"propertyValue"},"sku":"SKUSKUSKU","return_reason":null,"return_message":null}],"documents":[],"type":null,"shipment_uuid":"f893c98c-43a6-49bb-9dda-9bf3e76a87ad","shipping_method":null,"external_order_id":"36054805","external_shipment_id":"","external_reference":null,"is_return":false,"note":""}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->createParcel(
             new Address('Dr. Coffee', null, 'Street', 'Place', '7837', 'BM', 'drcoffee@drcoffee.dr', '123', null, 'Unit 83'),
@@ -382,6 +335,9 @@ class ClientTest extends TestCase
             ]
         );
 
+        $this->assertEquals('POST', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels', $response->getRequestUrl());
+        $this->assertEquals('{"parcel":{"name":"Dr. Coffee","company_name":"","address":"Street","address_2":"Unit 83","house_number":"123","city":"Place","postal_code":"7837","country":"BM","email":"drcoffee@drcoffee.dr","telephone":"","country_state":"","customs_invoice_nr":"customsInvoiceNumber","customs_shipment_type":2,"parcel_items":[{"description":"green tea","quantity":1,"weight":"0.123","value":15.2,"hs_code":"090210","origin_country":"EC"},{"description":"cardboard","quantity":3,"weight":"0.050","value":0.2,"hs_code":"090210","origin_country":"NL","sku":"SKUSKUSKU","product_id":"Product2839","properties":{"propertyKey":"propertyValue"}}]}}', $response->getRequestOptions()['body']);
         $this->assertEquals('customsInvoiceNumber', $parcel->getCustomsInvoiceNumber());
         $this->assertEquals(Parcel::CUSTOMS_SHIPMENT_TYPE_COMMERCIAL_GOODS, $parcel->getCustomsShipmentType());
         $this->assertCount(2, $parcel->getItems());
@@ -400,39 +356,32 @@ class ClientTest extends TestCase
         ], $parcel->getItems()[1]->toArray());
     }
 
+    /**
+     * Verifies that update only updates the address details (and not e.g., order number/weight)
+     */
     public function testUpdateParcel(): void
     {
-        // Test that update only updates the address details (and not e.g., order number/weight)
-        $this->mockHttpClient->expects($this->once())->method('request')
-            ->willReturnCallback(function () {
-                $this->assertEquals([
-                    'PUT',
-                    'parcels',
-                    ['json' => ['parcel' => ['id' => 8293794, 'name' => 'Completely different person', 'company_name' => 'Some company', 'address' => 'Rosebud', 'address_2' => 'Above the skies', 'house_number' => '2134A', 'city' => 'Almanda', 'postal_code' => '9238DD', 'country' => 'NL', 'email' => 'completelydifferent@email.com', 'telephone' => '+31699999999', 'country_state' => 'CS']]]
-                ], func_get_args());
-
-                return new Response(
-                    200,
-                    [],
-                    '{"parcel":{"id":8293794,"address":"Rosebud 2134 A","address_2":"Above the skies","address_divided":{"street":"Rosebud","house_number":"2134"},"city":"Almanda","company_name":"Some company","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"completelydifferent@email.com","name":"Completely different person","postal_code":"9238DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"+31699999999","tracking_number":"","weight":"2.490","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CS","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001"}}'
-                );
-            });
+        $response = new MockResponse('{"parcel":{"id":8293794,"address":"Rosebud 2134 A","address_2":"Above the skies","address_divided":{"street":"Rosebud","house_number":"2134"},"city":"Almanda","company_name":"Some company","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"completelydifferent@email.com","name":"Completely different person","postal_code":"9238DD","reference":"0","shipment":null,"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"+31699999999","tracking_number":"","weight":"2.490","label":{},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":"CS","customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":null,"external_order_id":"8293794","external_shipment_id":"201900001"}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->updateParcel(8293794, new Address('Completely different person', 'Some company', 'Rosebud', 'Almanda', '9238DD', 'NL', 'completelydifferent@email.com', '2134A', '+31699999999', 'Above the skies', 'CS'));
 
+        $this->assertEquals('PUT', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels', $response->getRequestUrl());
+        $this->assertEquals('{"parcel":{"id":8293794,"name":"Completely different person","company_name":"Some company","address":"Rosebud","address_2":"Above the skies","house_number":"2134A","city":"Almanda","postal_code":"9238DD","country":"NL","email":"completelydifferent@email.com","telephone":"+31699999999","country_state":"CS"}}', $response->getRequestOptions()['body']);
         $this->assertEquals('Some company', $parcel->getAddress()->getCompanyName());
     }
 
     public function testCreateLabel(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"parcel":{"id":8293794,"address":"Rosebud 2134 A","address_2":"","address_divided":{"street":"Rosebud","house_number":"2134"},"city":"Almanda","company_name":"Some company","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"completelydifferent@email.com","name":"Completely different person","postal_code":"9238 DD","reference":"0","shipment":{"id":117,"name":"DHLForYou Drop Off"},"status":{"id":1000,"message":"Ready to send"},"to_service_point":null,"telephone":"+31699999999","tracking_number":"JVGL4004421100020097","weight":"2.490","label":{"label_printer":"https://panel.sendcloud.sc/api/v2/labels/label_printer/8293794","normal_printer":["https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=0","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=1","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=2","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=3"]},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":"parcel","shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":117,"external_order_id":"8293794","external_shipment_id":"201900001","carrier":{"code":"dhl"},"tracking_url":"https://jouwweb.shipping-portal.com/tracking/?country=nl&tracking_number=jvgl4004421100020097&postal_code=9238dd"}}'
-        ));
+        $response = new MockResponse('{"parcel":{"id":8293794,"address":"Rosebud 2134 A","address_2":"","address_divided":{"street":"Rosebud","house_number":"2134"},"city":"Almanda","company_name":"Some company","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"11-03-2019 14:35:10","email":"completelydifferent@email.com","name":"Completely different person","postal_code":"9238 DD","reference":"0","shipment":{"id":117,"name":"DHLForYou Drop Off"},"status":{"id":1000,"message":"Ready to send"},"to_service_point":null,"telephone":"+31699999999","tracking_number":"JVGL4004421100020097","weight":"2.490","label":{"label_printer":"https://panel.sendcloud.sc/api/v2/labels/label_printer/8293794","normal_printer":["https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=0","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=1","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=2","https://panel.sendcloud.sc/api/v2/labels/normal_printer/8293794?start_from=3"]},"customs_declaration":{},"order_number":"201900001","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":"parcel","shipment_uuid":"7ade61ad-c21a-4beb-b7fd-2f579feacdb6","shipping_method":117,"external_order_id":"8293794","external_shipment_id":"201900001","carrier":{"code":"dhl"},"tracking_url":"https://jouwweb.shipping-portal.com/tracking/?country=nl&tracking_number=jvgl4004421100020097&postal_code=9238dd"}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->createLabel(8293794, 117, 61361);
 
+        $this->assertEquals('PUT', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels', $response->getRequestUrl());
+        $this->assertEquals('{"parcel":{"id":8293794,"shipment":{"id":117},"sender_address":61361,"request_label":true}}', $response->getRequestOptions()['body']);
         $this->assertEquals(Parcel::STATUS_READY_TO_SEND, $parcel->getStatusId());
         $this->assertEquals('JVGL4004421100020097', $parcel->getTrackingNumber());
         $this->assertEquals('https://jouwweb.shipping-portal.com/tracking/?country=nl&tracking_number=jvgl4004421100020097&postal_code=9238dd', $parcel->getTrackingUrl());
@@ -445,45 +394,39 @@ class ClientTest extends TestCase
 
     public function testGetParcel(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"parcel":{"id":2784972,"address":"Teststraat 12 A10","address_2":"","address_divided":{"street":"Teststraat","house_number":"12"},"city":"Woonplaats","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"27-08-2018 11:32:04","email":"sjoerd@jouwweb.nl","name":"Sjoerd Nuijten","postal_code":"7777 AA","reference":"0","shipment":{"id":8,"name":"Unstamped letter"},"status":{"id":11,"message":"Delivered"},"to_service_point":null,"telephone":"","tracking_number":"3SYZXG192833973","weight":"1.000","label":{"label_printer":"https://panel.sendcloud.sc/api/v2/labels/label_printer/13846453","normal_printer":["https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=0","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=1","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=2","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=3"]},"customs_declaration":{},"order_number":"201806006","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":"parcel","shipment_uuid":"cb1e0f2d-4e7f-456b-91fe-0bcf09847d10","shipping_method":39,"external_order_id":"2784972","external_shipment_id":"201806006","carrier":{"code":"postnl"},"tracking_url":"https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG192833973&destination=NL&lang=nl&source=NL&type=parcel&verification=7777AA"}}'
-        ));
+        $response = new MockResponse('{"parcel":{"id":2784972,"address":"Teststraat 12 A10","address_2":"","address_divided":{"street":"Teststraat","house_number":"12"},"city":"Woonplaats","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"27-08-2018 11:32:04","email":"sjoerd@jouwweb.nl","name":"Sjoerd Nuijten","postal_code":"7777 AA","reference":"0","shipment":{"id":8,"name":"Unstamped letter"},"status":{"id":11,"message":"Delivered"},"to_service_point":null,"telephone":"","tracking_number":"3SYZXG192833973","weight":"1.000","label":{"label_printer":"https://panel.sendcloud.sc/api/v2/labels/label_printer/13846453","normal_printer":["https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=0","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=1","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=2","https://panel.sendcloud.sc/api/v2/labels/normal_printer/13846453?start_from=3"]},"customs_declaration":{},"order_number":"201806006","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":"parcel","shipment_uuid":"cb1e0f2d-4e7f-456b-91fe-0bcf09847d10","shipping_method":39,"external_order_id":"2784972","external_shipment_id":"201806006","carrier":{"code":"postnl"},"tracking_url":"https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG192833973&destination=NL&lang=nl&source=NL&type=parcel&verification=7777AA"}}');
+        $this->configureApiResponse($response);
 
         $parcel = $this->client->getParcel(2784972);
 
+        $this->assertEquals('GET', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/2784972', $response->getRequestUrl());
         $this->assertEquals(2784972, $parcel->getId());
         $this->assertEquals(Parcel::STATUS_DELIVERED, $parcel->getStatusId());
     }
 
     public function testCancelParcel(): void
     {
-        $this->mockHttpClient->expects($this->exactly(2))->method('request')->willReturnCallback(function ($method, $url) {
-            $parcelId = (int)explode('/', $url)[1];
-
-            if ($parcelId === 8293794) {
-                return new Response(200, [], '{"status":"deleted","message":"Parcel has been deleted"}');
-            }
-
-            throw new RequestException(
-                'Client error: ...',
-                new Request('POST', 'url'),
-                new Response(400, [], '{"status":"failed","message":"Shipped parcels, or parcels being shipped, can no longer be cancelled."}')
-            );
-        });
+        $response1 = new MockResponse('{"status":"deleted","message":"Parcel has been deleted"}');
+        $response2 = new MockResponse('{"status":"failed","message":"Shipped parcels, or parcels being shipped, can no longer be cancelled."}', [
+            'http_code' => 400,
+        ]);
+        $this->configureApiResponse([$response1, $response2]);
 
         $this->assertTrue($this->client->cancelParcel(8293794));
+        $this->assertEquals('POST', $response1->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/8293794/cancel', $response1->getRequestUrl());
+
         $this->assertFalse($this->client->cancelParcel(2784972));
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/2784972/cancel', $response2->getRequestUrl());
     }
 
     public function testParseRequestException(): void
     {
-        $this->mockHttpClient->method('request')->willThrowException(new RequestException(
-            "Client error: `GET https://panel.sendcloud.sc/api/v2/user` resulted in a `401 Unauthorized` response:\n{\"error\":{\"message\":\"Invalid username/password.\",\"request\":\"api/v2/user\",\"code\":401}}\n))",
-            new Request('GET', 'https://some.uri'),
-            new Response(401, [], '{"error":{"message":"Invalid username/password.","request":"api/v2/user","code":401}}')
-        ));
+        $response = new MockResponse('{"error":{"message":"Invalid username/password.","request":"api/v2/user","code":401}}', [
+            'http_code' => 401,
+        ]);
+        $this->configureApiResponse($response);
 
         try {
             $this->client->getUser();
@@ -497,10 +440,9 @@ class ClientTest extends TestCase
 
     public function testParseRequestExceptionNoBody(): void
     {
-        $this->mockHttpClient->method('request')->willThrowException(new ConnectException(
-            'Failed to reach server or something.',
-            new Request('GET', 'https://some.uri')
-        ));
+        $response = new MockResponse('');
+        $response->cancel();
+        $this->configureApiResponse($response);
 
         try {
             $this->client->getUser();
@@ -514,27 +456,28 @@ class ClientTest extends TestCase
 
     public function testGetReturnPortalUrl(): void
     {
-        $this->mockHttpClient->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"url":"https://awesome.shipping-portal.com/returns/initiate/HocusBogusPayloadPath/"}'
-        ));
+        $response = new MockResponse('{"url":"https://awesome.shipping-portal.com/returns/initiate/HocusBogusPayloadPath/"}');
+        $this->configureApiResponse($response);
 
         $this->assertEquals(
             'https://awesome.shipping-portal.com/returns/initiate/HocusBogusPayloadPath/',
             $this->client->getReturnPortalUrl(9265)
         );
+        $this->assertEquals('GET', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/9265/return_portal_url', $response->getRequestUrl());
     }
 
     public function testGetReturnPortalUrlNotFound(): void
     {
-        $this->mockHttpClient->method('request')->willThrowException(new ClientException(
-            "Client error: `GET https://panel.sendcloud.sc/api/v2/parcels/23676385/return_portal_url` resulted in a `404 Not Found` response:\n{\"url\":null}\n",
-            new Request('GET', 'https://some.url'),
-            new Response(404, [], '{"url":null}')
-        ));
+        $response = new MockResponse('{"url":"https://awesome.shipping-portal.com/returns/initiate/HocusBogusPayloadPath/"}', [
+            'http_code' => 404,
+        ]);
+        $this->configureApiResponse($response);
 
         $this->assertNull($this->client->getReturnPortalUrl(9265));
+        $this->assertEquals('GET', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/9265/return_portal_url', $response->getRequestUrl());
+
     }
 
     public function testGetBulkLabelPdf(): void
@@ -590,13 +533,12 @@ class ClientTest extends TestCase
 
     public function testGetParcelDocumentReturnsTheRequestedContent(): void
     {
-        $this->mockHttpClient->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            'The ZPL content'
-        ));
+        $response = new MockResponse('The ZPL content');
+        $this->configureApiResponse($response);
 
         $this->assertEquals('The ZPL content', $this->client->getParcelDocument(1, Parcel::DOCUMENT_TYPE_LABEL, Parcel::DOCUMENT_CONTENT_TYPE_ZPL, Parcel::DOCUMENT_DPI_203));
+        $this->assertEquals('GET', $response->getRequestMethod());
+        $this->assertEquals('https://panel.sendcloud.sc/api/v2/parcels/1/documents/label?dpi=203', $response->getRequestUrl());
     }
 
     /**

--- a/test/ServicePointsClientTest.php
+++ b/test/ServicePointsClientTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Test\JouwWeb\Sendcloud;
+
+use JouwWeb\Sendcloud\ServicePointsClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ServicePointsClientTest extends TestCase
+{
+    private HttpClientInterface&MockObject $httpClientMock;
+
+    private ServicePointsClient $servicePointsClient;
+
+    public function setUp(): void
+    {
+        $this->httpClientMock = $this->createMock(HttpClientInterface::class);
+        $this->servicePointsClient = new ServicePointsClient(
+            publicKey: 'handsome public key',
+            secretKey: 'gorgeous secret key',
+            partnerId: 'aPartnerId',
+            httpClient: $this->httpClientMock,
+        );
+    }
+
+    public function testSearchServicePoints(): void
+    {
+        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            [],
+            '[
+                {"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true},
+                {"id":2,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true}
+            ]'
+        ));
+
+        $servicePoints = $this->servicePointsClient->searchServicePoints(country: 'NL');
+
+        $this->assertCount(2, $servicePoints);
+        $this->assertEquals(1, $servicePoints[0]->getId());
+        $this->assertEquals(2, $servicePoints[1]->getId());
+    }
+
+    public function testSearchServicePointWithDistance(): void
+    {
+        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            [],
+            '[
+                {"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":381}
+            ]'
+        ));
+
+        $servicePoints = $this->servicePointsClient->searchServicePoints(country: 'NL', latitude: 0, longitude: 0);
+
+        $this->assertCount(1, $servicePoints);
+        $this->assertEquals(1, $servicePoints[0]->getId());
+        $this->assertNotNull($servicePoints[0]->getDistance());
+    }
+
+    public function testGetServicePoint(): void
+    {
+        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
+            200,
+            [],
+            '{"id":26,"code":"4c8181feec8f49fdbe67d9c9f6aaaf6f","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"DUMMY-3f1d6384391f45ce","street":"Sesamstraat","house_number":"40","postal_code":"5699YE","city":"Eindhoven","latitude":"51.440400","longitude":"5.475800","email":"devnull@sendcloud.nl","phone":"+31401234567","homepage":"https://www.sendcloud.nl","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["13:30 - 17:15"],"1":["09:00 - 12:00","13:30 - 17:15"],"2":["09:00 - 12:00","13:30 - 17:15"],"3":[],"4":["09:00 - 12:00","13:30 - 17:15"],"5":["09:00 - 12:00","13:30 - 17:15"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":361}'
+        ));
+
+        $extraData = [
+            'partner_name' => 'PostNL',
+            'sales_channel' => 'AFHAALPUNT',
+            'terminal_type' => 'NRS',
+            'retail_network_id' => 'PNPNL-01',
+        ];
+
+        $formattedOpeningTimes = [
+            '0' => [
+                '13:30 - 17:15',
+            ],
+            '1' => [
+                '09:00 - 12:00',
+                '13:30 - 17:15',
+            ],
+            '2' =>  [
+                '09:00 - 12:00',
+                '13:30 - 17:15',
+            ],
+            '3' => [],
+            '4' =>  [
+                '09:00 - 12:00',
+                '13:30 - 17:15',
+            ],
+            '5' => [
+                '09:00 - 12:00',
+                '13:30 - 17:15',
+            ],
+            '6' => [],
+        ];
+
+        $servicePoint = $this->servicePointsClient->getServicePoint(26);
+
+        $this->assertEquals(26, $servicePoint->getId());
+        $this->assertEquals('4c8181feec8f49fdbe67d9c9f6aaaf6f', $servicePoint->getCode());
+        $this->assertTrue($servicePoint->isActive());
+        $this->assertNull($servicePoint->getShopType());
+        $this->assertEquals($extraData, $servicePoint->getExtraData());
+        $this->assertEquals('DUMMY-3f1d6384391f45ce', $servicePoint->getName());
+        $this->assertEquals('Sesamstraat', $servicePoint->getStreet());
+        $this->assertEquals('40', $servicePoint->getHouseNumber());
+        $this->assertEquals('5699YE', $servicePoint->getPostalCode());
+        $this->assertEquals('Eindhoven', $servicePoint->getCity());
+        $this->assertEquals('51.440400', $servicePoint->getLatitude());
+        $this->assertEquals('5.475800', $servicePoint->getLongitude());
+        $this->assertEquals('devnull@sendcloud.nl', $servicePoint->getEmail());
+        $this->assertEquals('+31401234567', $servicePoint->getPhone());
+        $this->assertEquals('https://www.sendcloud.nl', $servicePoint->getHomepage());
+        $this->assertEquals('postnl', $servicePoint->getCarrier());
+        $this->assertEquals('NL', $servicePoint->getCountry());
+        $this->assertEquals($formattedOpeningTimes, $servicePoint->getFormattedOpeningTimes());
+        $this->assertTrue($servicePoint->isOpenTomorrow());
+        $this->assertTrue($servicePoint->isOpenUpcomingWeek());
+        $this->assertEquals(361, $servicePoint->getDistance());
+    }
+}

--- a/test/ServicePointsClientTest.php
+++ b/test/ServicePointsClientTest.php
@@ -3,40 +3,32 @@
 namespace Test\JouwWeb\Sendcloud;
 
 use JouwWeb\Sendcloud\ServicePointsClient;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class ServicePointsClientTest extends TestCase
 {
-    private HttpClientInterface&MockObject $httpClientMock;
-
     private ServicePointsClient $servicePointsClient;
 
     public function setUp(): void
     {
-        $this->httpClientMock = $this->createMock(HttpClientInterface::class);
         $this->servicePointsClient = new ServicePointsClient(
             publicKey: 'handsome public key',
             secretKey: 'gorgeous secret key',
             partnerId: 'aPartnerId',
-            httpClient: $this->httpClientMock,
+            httpClient: new MockHttpClient(),
         );
     }
 
     public function testSearchServicePoints(): void
     {
-        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '[
-                {"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true},
-                {"id":2,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true}
-            ]'
-        ));
+        $response = new MockResponse('[{"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true},{"id":2,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true}]');
+        $this->configureApiResponse($response);
 
         $servicePoints = $this->servicePointsClient->searchServicePoints(country: 'NL');
 
+        $this->assertEquals('https://servicepoints.sendcloud.sc/api/v2/service-points?country=NL', $response->getRequestUrl());
         $this->assertCount(2, $servicePoints);
         $this->assertEquals(1, $servicePoints[0]->getId());
         $this->assertEquals(2, $servicePoints[1]->getId());
@@ -44,16 +36,12 @@ class ServicePointsClientTest extends TestCase
 
     public function testSearchServicePointWithDistance(): void
     {
-        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '[
-                {"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":381}
-            ]'
-        ));
+        $response = new MockResponse('[{"id":1,"code":"217165","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"Media Markt Eindhoven Centrum B.V.","street":"Boschdijktunnel","house_number":"1","postal_code":"5611AG","city":"EINDHOVEN","latitude":"51.441444","longitude":"5.475185","email":"","phone":"","homepage":"","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["10:00 - 20:00"],"1":["10:00 - 20:00"],"2":["10:00 - 20:00"],"3":["10:00 - 20:00"],"4":["10:00 - 20:00"],"5":["10:00 - 18:00"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":381}]');
+        $this->configureApiResponse($response);
 
         $servicePoints = $this->servicePointsClient->searchServicePoints(country: 'NL', latitude: 0, longitude: 0);
 
+        $this->assertEquals('https://servicepoints.sendcloud.sc/api/v2/service-points?country=NL&latitude=0&longitude=0', $response->getRequestUrl());
         $this->assertCount(1, $servicePoints);
         $this->assertEquals(1, $servicePoints[0]->getId());
         $this->assertNotNull($servicePoints[0]->getDistance());
@@ -61,11 +49,8 @@ class ServicePointsClientTest extends TestCase
 
     public function testGetServicePoint(): void
     {
-        $this->httpClientMock->expects($this->once())->method('request')->willReturn(new Response(
-            200,
-            [],
-            '{"id":26,"code":"4c8181feec8f49fdbe67d9c9f6aaaf6f","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"DUMMY-3f1d6384391f45ce","street":"Sesamstraat","house_number":"40","postal_code":"5699YE","city":"Eindhoven","latitude":"51.440400","longitude":"5.475800","email":"devnull@sendcloud.nl","phone":"+31401234567","homepage":"https://www.sendcloud.nl","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["13:30 - 17:15"],"1":["09:00 - 12:00","13:30 - 17:15"],"2":["09:00 - 12:00","13:30 - 17:15"],"3":[],"4":["09:00 - 12:00","13:30 - 17:15"],"5":["09:00 - 12:00","13:30 - 17:15"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":361}'
-        ));
+        $response = new MockResponse('{"id":26,"code":"4c8181feec8f49fdbe67d9c9f6aaaf6f","is_active":true,"shop_type":null,"extra_data":{"partner_name":"PostNL","sales_channel":"AFHAALPUNT","terminal_type":"NRS","retail_network_id":"PNPNL-01"},"name":"DUMMY-3f1d6384391f45ce","street":"Sesamstraat","house_number":"40","postal_code":"5699YE","city":"Eindhoven","latitude":"51.440400","longitude":"5.475800","email":"devnull@sendcloud.nl","phone":"+31401234567","homepage":"https://www.sendcloud.nl","carrier":"postnl","country":"NL","formatted_opening_times":{"0":["13:30 - 17:15"],"1":["09:00 - 12:00","13:30 - 17:15"],"2":["09:00 - 12:00","13:30 - 17:15"],"3":[],"4":["09:00 - 12:00","13:30 - 17:15"],"5":["09:00 - 12:00","13:30 - 17:15"],"6":[]},"open_tomorrow":true,"open_upcoming_week":true,"distance":361}');
+        $this->configureApiResponse($response);
 
         $extraData = [
             'partner_name' => 'PostNL',
@@ -100,6 +85,7 @@ class ServicePointsClientTest extends TestCase
 
         $servicePoint = $this->servicePointsClient->getServicePoint(26);
 
+        $this->assertEquals('https://servicepoints.sendcloud.sc/api/v2/service-points/26', $response->getRequestUrl());
         $this->assertEquals(26, $servicePoint->getId());
         $this->assertEquals('4c8181feec8f49fdbe67d9c9f6aaaf6f', $servicePoint->getCode());
         $this->assertTrue($servicePoint->isActive());
@@ -121,5 +107,13 @@ class ServicePointsClientTest extends TestCase
         $this->assertTrue($servicePoint->isOpenTomorrow());
         $this->assertTrue($servicePoint->isOpenUpcomingWeek());
         $this->assertEquals(361, $servicePoint->getDistance());
+    }
+
+    private function configureApiResponse(MockResponse|array $responses): void
+    {
+        $httpClientProperty = new \ReflectionProperty($this->servicePointsClient, 'httpClient');
+        /** @var MockHttpClient $httpClient */
+        $httpClient = $httpClientProperty->getValue($this->servicePointsClient);
+        $httpClient->setResponseFactory($responses);
     }
 }

--- a/test/UtilityTest.php
+++ b/test/UtilityTest.php
@@ -26,7 +26,9 @@ class UtilityTest extends TestCase
         $this->addToAssertionCount(1);
 
         try {
-            Utility::verifyWebhookRequest($request->withBody(Utils::streamFor(substr($payload, 0, -1))), $secretKey);
+            /** @var Request $invalidRequest */
+            $invalidRequest = $request->withBody(Utils::streamFor(substr($payload, 0, -1)));
+            Utility::verifyWebhookRequest($invalidRequest, $secretKey);
             $this->fail('Invalid request was validated correctly.');
         } catch (SendcloudWebhookException $exception) {
             $this->assertEquals(SendcloudWebhookException::CODE_VERIFICATION_FAILED, $exception->getCode());


### PR DESCRIPTION
- Rewrite to use Symfony's HTTP client and accept it as a ctor argument. Closes #43.
- Uses dedicated mock client and responses in tests and verifies URLs, methods and payloads where relevant.
- `symfony/http-client` is a required dependency (wide version match) because I want the library to work out of the box even if you don't inject your own client.
- [ ] Requires major version change because new (autowired) client may behave differently or express different limits (memory, timing).