### PR TITLE
Update delivery modes on getShippingProducts

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -150,7 +150,7 @@ class Client
      * @param bool|null $withReturn When true, methods returned can be used for making a return shipment.
      * @return ShippingProduct[]
      * @throws SendcloudClientException
-     * @see https://sendcloud.dev/docs/shipping/shipping_products/
+     * @see https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/shipping-products/operations/list-shipping-products
      */
     public function getShippingProducts(
         string $fromCountry,

--- a/src/Model/ShippingProduct.php
+++ b/src/Model/ShippingProduct.php
@@ -6,13 +6,15 @@ class ShippingProduct
 {
     public const DELIVERY_MODE_HOME_DELIVERY = 'home_delivery';
     public const DELIVERY_MODE_MAILBOX = 'mailbox';
-    public const DELIVERY_MODE_POBOX = 'pobox';
     public const DELIVERY_MODE_SERVICE_POINT = 'service_point';
+    public const DELIVERY_MODE_LOCKER = 'locker';
+    public const DELIVERY_MODE_LOCKER_OR_SERVICE_POINT = 'locker_or_service_point';
     public const DELIVERY_MODES = [
         self::DELIVERY_MODE_HOME_DELIVERY,
         self::DELIVERY_MODE_MAILBOX,
-        self::DELIVERY_MODE_POBOX,
         self::DELIVERY_MODE_SERVICE_POINT,
+        self::DELIVERY_MODE_LOCKER,
+        self::DELIVERY_MODE_LOCKER_OR_SERVICE_POINT,
     ];
 
     public const WEIGHT_UNIT_GRAM = 'gram';


### PR DESCRIPTION
In `ShippingProduct`, some values are listed to be used as the parameter `last_mile` of `getShippingProducts`.
```
    public const DELIVERY_MODES = [
        self::DELIVERY_MODE_HOME_DELIVERY,
        self::DELIVERY_MODE_MAILBOX,
        self::DELIVERY_MODE_POBOX,
        self::DELIVERY_MODE_SERVICE_POINT,
    ];
```

These values come from the official SendCloud documentation:
https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/shipping-products/operations/list-shipping-products

But, when the value `pobox` is used
(example of request: https://panel.sendcloud.sc/api/v2/shipping-products?from_country=NL&to_country=NL&last_mile=pobox), the API SendCloud response is:
```
{
    "error": {
        "code": 400,
        "request": "api/v2/shipping-products",
        "message": "last_mile: \"Input should be 'home_delivery', 'service_point', 'mailbox', 'locker' or 'locker_or_service_point'\""
    }
}
```

This pull request updates the usable values of `last_mile` regarding this API response.
By the way, the link to the official documentation for `getShippingProducts` being deprecated, it is updated too.